### PR TITLE
Added encoding and decoding for asterisk

### DIFF
--- a/can-attribute-encoder-test.js
+++ b/can-attribute-encoder-test.js
@@ -16,7 +16,8 @@ QUnit.test('encoding / decoding', function() {
 		'{foo bar}': ':lb:foo:s:bar:rb:',
 		'{foo/bar}': ':lb:foo:f:bar:rb:',
 		'{$^foobar}': ':lb::d::c:foobar:rb:',
-		'{^@bar}': ':lb::c::at:bar:rb:'
+		'{^@bar}': ':lb::c::at:bar:rb:',
+		'*foo': ':star:foo'
 	};
 
 	for (var key in encodings) {
@@ -40,7 +41,8 @@ QUnit.test('encoded values should work with setAttribute', function() {
 			'{foo bar}',
 			'{foo/bar}',
 			'{$^foobar}',
-			'{^@foo}'
+			'{^@foo}',
+			'*foo'
 		];
 
 	attributes.forEach(function(attr) {

--- a/can-attribute-encoder.js
+++ b/can-attribute-encoder.js
@@ -55,7 +55,8 @@ var regexes = {
 	uppercaseDelimiterThenChar: /:u:([a-z])/g,
 	caret: /\^/g,
 	dollar: /\$/g,
-	at: /@/g
+	at: /@/g,
+	star: /\*/g,
 };
 
 var delimiters = {
@@ -68,7 +69,8 @@ var delimiters = {
 	replaceRightBrace: ':rb:',
 	replaceCaret: ':c:',
 	replaceDollar: ':d:',
-	replaceAt: ':at:'
+	replaceAt: ':at:',
+	replaceAsterisk: ':star:'
 };
 
 var encoder = {};
@@ -134,7 +136,9 @@ encoder.encode = function(name) {
 		// encode $
 		.replace(regexes.dollar, delimiters.replaceDollar)
 		// encode @
-		.replace(regexes.at, delimiters.replaceAt);
+		.replace(regexes.at, delimiters.replaceAt)
+		// encode @
+		.replace(regexes.star, delimiters.replaceAsterisk);
 
 	return encoded;
 };
@@ -176,7 +180,9 @@ encoder.decode = function(name) {
 		//decode $
 		.replace(delimiters.replaceDollar, '$')
 		//decode @
-		.replace(delimiters.replaceAt, '@');
+		.replace(delimiters.replaceAt, '@')
+		//decode *
+		.replace(delimiters.replaceAsterisk, '*');
 
 	// decode uppercase characters in new bindings
 	if (!caseMattersAttributes[decoded] && decoded.match(regexes.uppercaseDelimiterThenChar)) {


### PR DESCRIPTION
This makes it so that `from:*something` gets encoded to `from:star:something`

Closes https://github.com/canjs/can-attribute-encoder/issues/6