### PR TITLE
Correctly encode/decode bindings like vm:sProperty:to

### DIFF
--- a/can-attribute-encoder-test.js
+++ b/can-attribute-encoder-test.js
@@ -8,6 +8,7 @@ QUnit.test('encoding / decoding', function() {
 		encodings = {
 		'on:fooBar': 'on:foo:u:bar',
 		'on:fooBar:by:bazQuz': 'on:foo:u:bar:by:baz:u:quz',
+		'vm:sProp:to': 'vm:s:u:prop:to',
 		'fooBar:to': 'foo:u:bar:to',
 		'fooBar:from': 'foo:u:bar:from',
 		'fooBar:bind': 'foo:u:bar:bind',
@@ -32,6 +33,7 @@ QUnit.test('encoded values should work with setAttribute', function() {
 		attributes = [
 			'on:fooBar',
 			'on:fooBar:by:bazQuz',
+			'vm:sProp:to',
 			'fooBar:to',
 			'fooBar:from',
 			'fooBar:bind',
@@ -89,4 +91,3 @@ QUnit.test('should throw if can-namespace.encoder is already defined', function(
 		start();
 	});
 });
-

--- a/can-attribute-encoder.js
+++ b/can-attribute-encoder.js
@@ -160,6 +160,16 @@ encoder.encode = function(name) {
 encoder.decode = function(name) {
 	var decoded = name;
 
+	// decode uppercase characters in new bindings
+	if (!caseMattersAttributes[decoded] && decoded.match(regexes.uppercaseDelimiterThenChar)) {
+		if (startsWith(decoded, 'on:') || endsWith(decoded, ':to') || endsWith(decoded, ':from') || endsWith(decoded, ':bind')) {
+			decoded = decoded
+				.replace(regexes.uppercaseDelimiterThenChar, function(match, char) {
+					return char.toUpperCase();
+				});
+		}
+	}
+
 	// decode left parentheses
 	decoded = decoded.replace(delimiters.replaceLeftParens, '(')
 		// decode right parentheses
@@ -178,16 +188,6 @@ encoder.decode = function(name) {
 		.replace(delimiters.replaceDollar, '$')
 		//decode @
 		.replace(delimiters.replaceAt, '@');
-
-	// decode uppercase characters in new bindings
-	if (!caseMattersAttributes[decoded] && decoded.match(regexes.uppercaseDelimiterThenChar)) {
-		if (startsWith(decoded, 'on:') || endsWith(decoded, ':to') || endsWith(decoded, ':from') || endsWith(decoded, ':bind')) {
-			decoded = decoded
-				.replace(regexes.uppercaseDelimiterThenChar, function(match, char) {
-					return char.toUpperCase();
-				});
-		}
-	}
 
 	return decoded;
 };


### PR DESCRIPTION
A binding such as `vm:sProperty:to` is encoded to `vm:s:u:property:to`, which is ambiguous to the decoder; should it decode `:s:` first or `:u:` first?

Previously, we decoded `:s:` first, which decoded `vm:s:u:property:to` to `vm u:property:to`. Now, we decode `:u:` first, which should be ok because only the new bindings need to encode uppercase with `:u:` and the new bindings don’t support spaces in them.

Fixes https://github.com/canjs/can-attribute-encoder/issues/11